### PR TITLE
Fix reference includes

### DIFF
--- a/mods-src/RustAndRails/rustandrails.csproj
+++ b/mods-src/RustAndRails/rustandrails.csproj
@@ -47,27 +47,35 @@
     <Reference Include="WindowsBase" />
     <Reference Include="VSSurvivalMod">
       <HintPath>$(AppData)\vintagestory\Mods\VSSurvivalMod.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="VSEssentials">
       <HintPath>$(AppData)\vintagestory\Mods\VSEssentials.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="VintagestoryAPI">
       <HintPath>$(AppData)\vintagestory\VintagestoryAPI.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="protobuf-net">
       <HintPath>$(AppData)\vintagestory\Lib\protobuf-net.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json">
       <HintPath>$(AppData)\vintagestory\Lib\Newtonsoft.Json.dll</HintPath>
+	  <Private>False</Private>
     </Reference>
     <Reference Include="0Harmony">
       <HintPath>$(AppData)\vintagestory\Lib\0Harmony.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="cairo-sharp">
       <HintPath>$(AppData)\vintagestory\Lib\cairo-sharp.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="VSCreativeMod">
       <HintPath>$(AppData)\vintagestory\Mods\VSCreativeMod.dll</HintPath>
+      <Private>False</Private>
     </Reference>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Adds back in the `<Private>False</Private>` attributes so we don't copy the VS standard dlls to the mod folder